### PR TITLE
Fix import case issues, improve XML directory search, and add zip input support for Sentinel-2 MSI

### DIFF
--- a/tmart/AEC/read_metadata_S2.py
+++ b/tmart/AEC/read_metadata_S2.py
@@ -16,6 +16,12 @@ def read_metadata_S2(file,config,sensor):
     import mgrs
     import Py6S, math
     
+    # Update `file` by searching metadata xml file
+    for root, dirs, files in os.walk(file):
+        if "MTD_MSIL1C.xml" in files:
+            xml_file = os.path.join(root, "MTD_MSIL1C.xml")
+    
+    file = os.path.dirname(xml_file)
     files = os.listdir(file)
     metadata = {}
     metadata['file'] = file
@@ -113,7 +119,7 @@ def read_metadata_S2(file,config,sensor):
                         metadata.update(xml)
     
     # Scaling factors 
-    xml2 = tmart.AEC.read_xml_S2_scene('{}/MTD_MSIL1C.xml'.format(file))
+    xml2 = tmart.AEC.read_xml_S2_scene(xml_file)
     metadata.update(xml2)
     
     # Others 

--- a/tmart/__init__.py
+++ b/tmart/__init__.py
@@ -12,7 +12,7 @@
 from .Surface import Surface, SpectralSurface
 from .Atmosphere import Atmosphere
 
-from .Tmart import Tmart
+from .tmart import Tmart
 
 from .tm_calcref import calc_ref 
 from .tm_geometry import dirP_to_coord

--- a/tmart/tmart.py
+++ b/tmart/tmart.py
@@ -21,7 +21,7 @@ import sys
 from .tm_geometry import dirP_to_coord 
 from .tm_intersect import intersect_line_DEMtri2
 from .tm_water import find_R_wc, RefraIdx
-from .Tmart2 import Tmart2
+from .tmart2 import Tmart2
 
 
 # Track progress in multiprocessing


### PR DESCRIPTION
Hi Yulun,

I've tested `tmart` on my Macbook and encountered a few issues, which I've addressed in this PR.

- Fixed import issues where `from .Tmart import Tmart` was used despite the actual file being lowercase `tmart`. Updated all references to lowercase to resolve this inconsistency.
- Resolved a problem with locating the `MTD_MSIL1C.xml` file by adding a mechanism using `os.walk()` to find the correct directory path.
- Added a new feature to `tmart/AEC/run.py` that allows direct input of Sentinel-2 MSI zip files. This update includes a function to automatically identify and unzip the file.

Testing was performed using the S2B_MSIL1C_20230910T023529_N0509_R089_T51RTQ_20230910T045347.SAFE.zip scene, which took about one hour on 8 cores.

Let me know if you have any questions or need further changes.

Regards,
Shun