### PR TITLE
Add NDWI mask threshold override to AEC.run

### DIFF
--- a/ins_aec.md
+++ b/ins_aec.md
@@ -50,7 +50,7 @@ When ``water_detection_method = NDWI`` in ``config.txt``, water identification i
 
 When ``water_detection_method = SWIR``, water pixels are identified as the SWIR band reflectance lower than the threshold ``mask_SWIR_threshold`` (default value: 0.03). Increase this value if a significant number of water pixels are falsely masked as land.
 
-Both ``mask_SWIR_threshold`` or ``mask_NDWI_threshold`` can be adjusted in ``config.txt``. Modifying ``mask_SWIR_threshold`` in the *AEC.run* function overwrites the value in ``config.txt``. Alternatively, setting ``AE_land`` to True enables AEC across the entire scene. 
+Both ``mask_SWIR_threshold`` or ``mask_NDWI_threshold`` can be adjusted in ``config.txt``. Modifying ``mask_SWIR_threshold`` or ``mask_NDWI_threshold`` in the *AEC.run* function overwrites the corresponding value in ``config.txt``. Alternatively, setting ``AE_land`` to True enables AEC across the entire scene.
 
 ## Additional arguments 
 

--- a/tmart/AEC/read_config.py
+++ b/tmart/AEC/read_config.py
@@ -9,7 +9,7 @@
 
 # Read configuration file 
 
-def read_config(mask_SWIR_threshold):
+def read_config(mask_SWIR_threshold, mask_NDWI_threshold):
     import os
     import pandas as pd
     
@@ -30,7 +30,10 @@ def read_config(mask_SWIR_threshold):
     
     if mask_SWIR_threshold is not None:
         result_dict['mask_SWIR_threshold']=mask_SWIR_threshold
-    
+
+    if mask_NDWI_threshold is not None:
+        result_dict['mask_NDWI_threshold']=mask_NDWI_threshold
+
     for k, v in result_dict.items():
         print(str(k) + ': '  + str(v))    
     

--- a/tmart/AEC/run.py
+++ b/tmart/AEC/run.py
@@ -9,7 +9,7 @@
 
 # Overall control of AEC
 
-def run(file, username=None, password=None, overwrite=False, AOT='MERRA2', n_photon=100_000, AOT_offset=0.0, n_jobs=100, mask_SWIR_threshold=None, atm_info_file=None):
+def run(file, username=None, password=None, overwrite=False, AOT='MERRA2', n_photon=100_000, AOT_offset=0.0, n_jobs=100, mask_SWIR_threshold=None, mask_NDWI_threshold=None, atm_info_file=None):
     '''Run adjacency-effect correction on satellite files. See 'Introduction - Adjacency-Effect Correction' for detailed instructions.
     
     Arguments:
@@ -23,6 +23,7 @@ def run(file, username=None, password=None, overwrite=False, AOT='MERRA2', n_pho
     * ``AOT_offset`` -- Float. Value added to AOT at 550nm. If resulted AOT is negative, it will be corrected to 0.
     * ``n_jobs`` -- Int. Number of jobs in Python multiprocessing. One CPU core processes one job at a time. n_photon is evenly distributed across the jobs.
     * ``mask_SWIR_threshold`` -- Float. Reflectance threshold in a SWIR band used to mask non-water pixels in the processing. If specified, this overwrites the value in config.txt. 
+    * ``mask_NDWI_threshold`` -- Float. NDWI threshold used to mask non-water pixels in the processing. If specified, this overwrites the value in config.txt.
     * ``atm_info_file`` -- String. Path to a tmart_atm_info_*.txt file. When provided, T-Mart skips downloading ancillary data and reads aerosol/atmosphere information from this file.
 
     Example usage::
@@ -102,10 +103,10 @@ def run(file, username=None, password=None, overwrite=False, AOT='MERRA2', n_pho
     
     # S2/L89
     if file_is_dir: 
-        tmart_out = tmart.AEC.run_regular(file, username, password, AOT, AOT_offset, n_photon, AEC_record, basename_before_period, n_jobs, mask_SWIR_threshold, atm_info_file=atm_info_file)
+        tmart_out = tmart.AEC.run_regular(file, username, password, AOT, AOT_offset, n_photon, AEC_record, basename_before_period, n_jobs, mask_SWIR_threshold, mask_NDWI_threshold, atm_info_file=atm_info_file)
     # ACOLITE L1R 
     else:
-        tmart_out = tmart.AEC.run_acoliteL1R(file, username, password, AOT, AOT_offset, n_photon, AEC_record, basename_before_period, n_jobs, mask_SWIR_threshold, atm_info_file=atm_info_file)
+        tmart_out = tmart.AEC.run_acoliteL1R(file, username, password, AOT, AOT_offset, n_photon, AEC_record, basename_before_period, n_jobs, mask_SWIR_threshold, mask_NDWI_threshold, atm_info_file=atm_info_file)
     
     # Stop logging 
     sys.stdout = orig_stdout

--- a/tmart/AEC/run_acoliteL1R.py
+++ b/tmart/AEC/run_acoliteL1R.py
@@ -9,7 +9,7 @@
 
 # Run on ACOLITE L1R files, currently supports PRSIMA only 
 
-def run_acoliteL1R(file, username, password, AOT, AOT_offset, n_photon, AEC_record, basename, njobs, mask_SWIR_threshold, atm_info_file=None):
+def run_acoliteL1R(file, username, password, AOT, AOT_offset, n_photon, AEC_record, basename, njobs, mask_SWIR_threshold, mask_NDWI_threshold, atm_info_file=None):
  
     import tmart
     import sys, os, time
@@ -18,7 +18,7 @@ def run_acoliteL1R(file, username, password, AOT, AOT_offset, n_photon, AEC_reco
     from scipy import signal, interpolate
         
     # Read configuration
-    config = tmart.AEC.read_config(mask_SWIR_threshold)
+    config = tmart.AEC.read_config(mask_SWIR_threshold, mask_NDWI_threshold)
     
     # Open netcdf file 
     dset = nc4.Dataset(file, 'r+')

--- a/tmart/AEC/run_regular.py
+++ b/tmart/AEC/run_regular.py
@@ -9,13 +9,13 @@
 
 # Run on Landsat and Sentinel series 
 
-def run_regular(file, username, password, AOT, AOT_offset, n_photon, AEC_record, basename, njobs, mask_SWIR_threshold, atm_info_file=None): 
+def run_regular(file, username, password, AOT, AOT_offset, n_photon, AEC_record, basename, njobs, mask_SWIR_threshold, mask_NDWI_threshold, atm_info_file=None):
  
     import tmart
     import sys, os
     
     # read configuration
-    config = tmart.AEC.read_config(mask_SWIR_threshold)
+    config = tmart.AEC.read_config(mask_SWIR_threshold, mask_NDWI_threshold)
 
     # identify sensor
     print('\nReading image files: ')


### PR DESCRIPTION
### Motivation
- Allow callers of `tmart.AEC.run` to override the NDWI water-mask threshold at runtime, matching the existing `mask_SWIR_threshold` override behavior and making water-detection thresholding configurable per-run.

### Description
- Add `mask_NDWI_threshold` to the `tmart.AEC.run` function signature and its argument documentation in `tmart/AEC/run.py`.
- Propagate the new parameter through to both processing paths by updating the signatures and call sites of `run_regular` and `run_acoliteL1R` in `tmart/AEC/run_regular.py` and `tmart/AEC/run_acoliteL1R.py`.
- Change `tmart.AEC.read_config` in `tmart/AEC/read_config.py` to accept `mask_NDWI_threshold` and overwrite `result_dict['mask_NDWI_threshold']` when a value is provided.
- Update `ins_aec.md` to document that either `mask_SWIR_threshold` or `mask_NDWI_threshold` can be overridden via `AEC.run`.

### Testing
- Successfully ran `python -m py_compile` on the modified files `tmart/AEC/read_config.py`, `tmart/AEC/run.py`, `tmart/AEC/run_regular.py`, and `tmart/AEC/run_acoliteL1R.py`.
- Performed AST/signature checks to confirm `mask_NDWI_threshold` appears in `read_config` and `run` signatures and is positioned immediately after `mask_SWIR_threshold`, which passed.
- Attempt to import `tmart` to inspect the runtime signature could not complete because `numpy` is not installed in the environment, so runtime import-based checks were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a361aa67a80832dbceed85de8bdaa93)